### PR TITLE
added cstddef header to cpp/lookupTable.hpp so as to elude ptrdiff_t …

### DIFF
--- a/cpp/lookupTable.hpp
+++ b/cpp/lookupTable.hpp
@@ -24,6 +24,7 @@
 
 #include "activation.hpp"
 #include "interpolate.hpp"
+#include <cstddef>
 
 namespace tinymind {
     template<typename ValueType>


### PR DESCRIPTION
A file of lookupTable.hpp misses cstddef header inclusion, so the compilation encounters an error related to undefined ptrdiff_t. 